### PR TITLE
I created a package.json file for npm dependencies and npm linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "web-irc",
+  "description": "In-browser IRC client",
+  "author": "Aaron Kavlie",
+  "version": "0.0.1",
+  "dependencies": {
+    "express": "2.5.x",
+    "irc": "0.3.x",
+    "socket.io": "0.8.x"
+  },
+  "devDependencies": {
+  },
+  "engine": "node >= 0.4.x"
+}


### PR DESCRIPTION
I made some guesses about dependencies, versions, and stuff i.e. I'm not sure if you'd rather have express 2.5.x or something more or less specific.

These were the npm dependencies I personally had to install with npm on Debian before node server.js would run without dependency errors.
# cat package.json

{
  "name": "web-irc",
  "description": "In-browser IRC client",
  "author": "Aaron Kavlie",
  "version": "0.0.1",
  "dependencies": {
    "express": "2.5.x",
    "irc": "0.3.x",
    "socket.io": "0.8.x"
  },
  "devDependencies": {
  },
  "engine": "node >= 0.4.x"
}
